### PR TITLE
feat: 공통 응답 클래스 추가

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,4 @@ ij_kotlin_allow_trailing_comma_on_call_site = false
 ij_kotlin_name_count_to_use_star_import = 2147483647
 ij_kotlin_name_count_to_use_star_import_for_members = 2147483647
 ij_kotlin_packages_to_use_import_on_demand = unset
+ktlint_standard_function-expression-body = disabled

--- a/moyoy-api/src/main/kotlin/com/moyoy/api/support/config/StaticRoutingConfig.kt
+++ b/moyoy-api/src/main/kotlin/com/moyoy/api/support/config/StaticRoutingConfig.kt
@@ -1,4 +1,4 @@
-package com.moyoy.api.config
+package com.moyoy.api.support.config
 
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry

--- a/moyoy-api/src/main/kotlin/com/moyoy/api/support/response/ApiResponse.kt
+++ b/moyoy-api/src/main/kotlin/com/moyoy/api/support/response/ApiResponse.kt
@@ -1,0 +1,26 @@
+package com.moyoy.api.support.response
+
+import org.springframework.http.HttpStatus.ACCEPTED
+import org.springframework.http.HttpStatus.NO_CONTENT
+import org.springframework.http.HttpStatus.OK
+
+class ApiResponse<T> private constructor(
+    val status: Int,
+    val code: String,
+    val message: String?,
+    val data: T?
+) {
+    companion object {
+        fun <S> success(data: S): ApiResponse<S> {
+            return ApiResponse(OK.value(), OK.reasonPhrase, null, data)
+        }
+
+        fun accepted(): ApiResponse<Nothing?> {
+            return ApiResponse(ACCEPTED.value(), ACCEPTED.reasonPhrase, null, null)
+        }
+
+        fun noContent(): ApiResponse<Nothing?> {
+            return ApiResponse(NO_CONTENT.value(), NO_CONTENT.reasonPhrase, null, null)
+        }
+    }
+}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #11 
<br />
## 🔎 PR 내용

기존 프로젝트에서 정해두었던 형식에 맞춰서 공통 응답 클래스 ApiResponse를 추가했습니다.

[기존 프로젝트 관련 PR](https://github.com/Mo-yoy/Moyoy-Backend/pull/12)


### 사용 예시
```kotlin
// 성공 응답
return ApiResponse.success(userData)

// 202 Accepted
return ApiResponse.accepted()

// 204 No Content
return ApiResponse.noContent()
```