### PR TITLE
fix: sonarqube Security Hotspot 문제 해결

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -41,4 +41,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
-        run: ./gradlew sonar --dependency-verification=off
+        run: ./gradlew sonar

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,3 @@
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=kotlin:S6474
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.gradle.kts

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,0 @@
-sonar.issue.ignore.multicriteria=e1
-sonar.issue.ignore.multicriteria.e1.ruleKey=kotlin:S6474
-sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.gradle.kts


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #13 

<br />

## 🔎 PR 내용

Gradle이 외부 라이브러리(Maven Central 등)에서 다운로드할 때 무결성 검증을 하고 있지 않아서 누가 중간에 라이브러리를 변조해도 모를 수 있다는 Security Hotspot 문제가 발생했습니다.

[sonarqube 권장 해결 방안](https://sonarcloud.io/organizations/mo-yoy/rules?open=kotlin%3AS6474&rule_key=kotlin%3AS6474&tab=how_to_fix)을 참고해 해당 문제를 해결하려 했으나, 해당 방식 처럼 모든 의존 라이브러리에 대한 체크섬 파일을 매번 생성하는 방식은 

의존 라이브러리에 대한 조금의 변경사항이 있을 때마다, 이를 검증할 해당 체크섬 파일을 계속 생성해야 해서 리소스도 너무 많이 들고 토이 프로젝트로 진행하는 현재 프로젝트에서 당장은 중요한 이슈가 아닌점을 고려하여 sonarcloud 에서 해당 이슈를 수동으로 safe 처리 하는 방식을 사용해서 해결했습니다.

